### PR TITLE
Fix build asset handling

### DIFF
--- a/ChatBotWindow/chatbot-window.php
+++ b/ChatBotWindow/chatbot-window.php
@@ -38,9 +38,8 @@ function cbw_options_page() {
 
 function cbw_register_assets() {
     $asset_url = plugin_dir_url(__FILE__) . 'assets/';
-    wp_enqueue_style('cbw-style', $asset_url . 'static/css/main.css');
-    wp_enqueue_script('cbw-runtime', $asset_url . 'static/js/runtime-main.js', [], null, true);
-    wp_enqueue_script('cbw-main', $asset_url . 'static/js/main.js', ['cbw-runtime'], null, true);
+    wp_enqueue_style('cbw-style', $asset_url . 'app.css');
+    wp_enqueue_script('cbw-main', $asset_url . 'app.js', [], null, true);
 }
 add_action('wp_enqueue_scripts', 'cbw_register_assets');
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,7 @@ WordPress に React 製のチャットボットを組み込むプラグインで
    ```bash
    npm run build
    ```
-4. 作成された `build` フォルダを `ChatBotWindow/assets` にコピーし、`ChatBotWindow` フォルダを zip 圧縮して WordPress にアップロードします。
+4. ビルドスクリプトにより `ChatBotWindow/assets` へ自動的にファイルが配置されます。完了したら `ChatBotWindow` フォルダを zip 圧縮して WordPress にアップロードします。
 
 ## WordPress への導入
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ To create the production build that will be packaged with the plugin:
 ```bash
 npm run build
 ```
-
-Copy the generated `build` directory to `ChatBotWindow/assets` and create a zip archive of the `ChatBotWindow` folder for uploading to WordPress.
+The build script automatically places the necessary files into `ChatBotWindow/assets`. Create a zip archive of the `ChatBotWindow` folder for uploading to WordPress.
 
 ## WordPress Installation
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "postbuild": "node scripts/copy-build.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/scripts/copy-build.js
+++ b/scripts/copy-build.js
@@ -2,7 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 const buildDir = path.join(__dirname, '..', 'build');
-const targetDir = path.join(__dirname, '..', 'react-db-plugin', 'assets');
+// Copy files into the plugin's assets directory
+const targetDir = path.join(__dirname, '..', 'ChatBotWindow', 'assets');
 
 if (!fs.existsSync(targetDir)) {
   fs.mkdirSync(targetDir, { recursive: true });


### PR DESCRIPTION
## Summary
- copy built React files into plugin assets automatically
- enqueue the single app.js/app.css bundle from the plugin
- update docs for the automated build step

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68424bc3c6788323b81ef9cb896b1ddc