### PR TITLE
Allow custom header for API key and add shortcode

### DIFF
--- a/ChatBotWindow/chatbot-window.php
+++ b/ChatBotWindow/chatbot-window.php
@@ -9,7 +9,6 @@ if (!defined('ABSPATH')) exit;
 
 function cbw_register_settings() {
     register_setting('cbw_options', 'cbw_settings');
-    register_setting('cbw_options', 'cbw_tasks', 'cbw_sanitize_tasks');
 }
 add_action('admin_init', 'cbw_register_settings');
 
@@ -20,57 +19,29 @@ add_action('admin_menu', 'cbw_add_admin_menu');
 
 function cbw_options_page() {
     $settings = get_option('cbw_settings');
-    $tasks    = get_option('cbw_tasks', []);
     ?>
     <div class="wrap">
         <h1>ChatBotWindow Settings</h1>
         <form method="post" action="options.php">
             <?php settings_fields('cbw_options'); ?>
             <table class="form-table" role="presentation">
-                <tr><th scope="row"><label for="cbw_api_url">API URL</label></th>
-                    <td><input type="text" id="cbw_api_url" name="cbw_settings[api_url]" value="<?php echo esc_attr($settings['api_url'] ?? ''); ?>" class="regular-text" /></td></tr>
-                <tr><th scope="row"><label for="cbw_api_key">API Key</label></th>
-                    <td><input type="text" id="cbw_api_key" name="cbw_settings[api_key]" value="<?php echo esc_attr($settings['api_key'] ?? ''); ?>" class="regular-text" /></td></tr>
-            </table>
-
-            <h2>Tasks</h2>
-            <table class="form-table" id="cbw-tasks-table">
                 <tr>
-                    <th>Task Name</th>
-                    <th>HTML</th>
+                    <th scope="row"><label for="cbw_api_url">API URL</label></th>
+                    <td><input type="text" id="cbw_api_url" name="cbw_settings[api_url]" value="<?php echo esc_attr($settings['api_url'] ?? ''); ?>" class="regular-text" /></td>
                 </tr>
-                <?php foreach ($tasks as $slug => $task) : ?>
                 <tr>
-                    <td><input type="text" name="cbw_tasks[<?php echo esc_attr($slug); ?>][name]" value="<?php echo esc_attr($task['name']); ?>" class="regular-text" /></td>
-                    <td><textarea name="cbw_tasks[<?php echo esc_attr($slug); ?>][html]" rows="3" class="large-text code"><?php echo esc_textarea($task['html']); ?></textarea></td>
+                    <th scope="row"><label for="cbw_api_key">API Key</label></th>
+                    <td><input type="text" id="cbw_api_key" name="cbw_settings[api_key]" value="<?php echo esc_attr($settings['api_key'] ?? ''); ?>" class="regular-text" /></td>
                 </tr>
-                <?php endforeach; ?>
-                <tr class="cbw-empty-row">
-                    <td><input type="text" name="cbw_tasks[new][name]" class="regular-text" /></td>
-                    <td><textarea name="cbw_tasks[new][html]" rows="3" class="large-text code"><div class="cbw-row">
-  <div class="cbw-col">Column 1</div>
-  <div class="cbw-col">Column 2</div>
-</div></textarea></td>
+                <tr>
+                    <th scope="row"><label for="cbw_api_header">API Key Header</label></th>
+                    <td><input type="text" id="cbw_api_header" name="cbw_settings[api_header]" value="<?php echo esc_attr($settings['api_header'] ?? ''); ?>" class="regular-text" /></td>
                 </tr>
             </table>
-            <p><button type="button" class="button" id="cbw-add-task">Add Task</button></p>
             <?php submit_button(); ?>
         </form>
-        <?php if (!empty($tasks)) : ?>
-        <h2>Shortcodes</h2>
-        <p>
-            <?php foreach ($tasks as $slug => $task) : ?>
-                <code>[cbw_task id="<?php echo esc_html($slug); ?>"]</code><br />
-            <?php endforeach; ?>
-        </p>
-        <?php endif; ?>
-        <script>
-        document.getElementById('cbw-add-task').addEventListener('click', function(){
-            const table = document.getElementById('cbw-tasks-table');
-            const clone = table.querySelector('.cbw-empty-row').cloneNode(true);
-            table.appendChild(clone);
-        });
-        </script>
+        <h2>Shortcode</h2>
+        <p><code>[chatbot_window]</code></p>
     </div>
     <?php
 }
@@ -82,6 +53,11 @@ function cbw_register_assets() {
 }
 add_action('wp_enqueue_scripts', 'cbw_register_assets');
 
+function cbw_chatbot_shortcode() {
+    return '<div id="root"></div>';
+}
+add_shortcode('chatbot_window', 'cbw_chatbot_shortcode');
+
 add_action('rest_api_init', function () {
     register_rest_route('chatbot/v1', '/query', [
         'methods' => 'POST',
@@ -91,13 +67,14 @@ add_action('rest_api_init', function () {
 
 function cbw_query_handler($request) {
     $settings = get_option('cbw_settings');
-    $api_url = $settings['api_url'];
-    $api_key = $settings['api_key'];
+    $api_url    = $settings['api_url'];
+    $api_key    = $settings['api_key'];
+    $api_header = $settings['api_header'] ?: 'X-API-KEY';
 
     $response = wp_remote_post($api_url, [
         'headers' => [
             'Content-Type' => 'application/json',
-            'X-API-KEY' => $api_key,
+            $api_header  => $api_key,
         ],
         'body' => json_encode(['query' => $request->get_json_params()['query'] ?? ''])
     ]);
@@ -109,28 +86,4 @@ function cbw_query_handler($request) {
     return json_decode(wp_remote_retrieve_body($response), true);
 }
 
-function cbw_sanitize_tasks($tasks) {
-    $sanitized = [];
-    if (!is_array($tasks)) return $sanitized;
-    foreach ($tasks as $task) {
-        if (empty($task['name'])) continue;
-        $slug = sanitize_title($task['name']);
-        $html = isset($task['html']) ? wp_kses_post($task['html']) : '';
-        $sanitized[$slug] = [
-            'name' => sanitize_text_field($task['name']),
-            'html' => $html,
-        ];
-    }
-    return $sanitized;
-}
-
-function cbw_task_shortcode($atts) {
-    $atts = shortcode_atts(['id' => ''], $atts);
-    $tasks = get_option('cbw_tasks', []);
-    if ($atts['id'] && isset($tasks[$atts['id']])) {
-        return $tasks[$atts['id']]['html'];
-    }
-    return '';
-}
-add_shortcode('cbw_task', 'cbw_task_shortcode');
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # ChatBotWindow プラグイン
 
-WordPress に React 製のチャットボットを組み込むプラグインです。UI には **Material UI** を使用し、外部 API との通信は WordPress の REST API を経由します。API URL と API キーはダッシュボードから設定可能です。
+WordPress に React 製のチャットボットを組み込むプラグインです。UI には **Material UI** を使用し、外部 API との通信は WordPress の REST API を経由します。API URL と API キー、そして送信ヘッダー名はダッシュボードから設定可能です。
 
 ## 開発手順
 
@@ -21,7 +21,8 @@ WordPress に React 製のチャットボットを組み込むプラグインで
 ## WordPress への導入
 
 1. 上記手順で作成した zip ファイルを WordPress のプラグイン画面からアップロードして有効化します。
-2. **設定 > ChatBotWindow** から API URL と API キーを保存します。
+2. **設定 > ChatBotWindow** から API URL と API キー、ヘッダー名を保存します。
+3. チャットボットを表示したいページに `[chatbot_window]` ショートコードを配置します。
 
 ## ディレクトリ構成
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ChatBotWindow Plugin
 
-This project provides a WordPress plugin that embeds a React based ChatBot window. The React app uses **Material UI** and communicates with an external API via a WordPress REST endpoint. Settings such as the API URL and key can be configured from the WordPress dashboard.
+This project provides a WordPress plugin that embeds a React based ChatBot window. The React app uses **Material UI** and communicates with an external API via a WordPress REST endpoint. Settings such as the API URL, key and header name can be configured from the WordPress dashboard.
 
 ## Development
 
@@ -23,7 +23,8 @@ The build script automatically places the necessary files into `ChatBotWindow/as
 1. Build the React application as described above.
 2. Create a zip file of the `ChatBotWindow` directory.
 3. Upload the zip file from the WordPress plugin screen and activate the plugin.
-4. Configure the API URL and API key in **Settings > ChatBotWindow**.
+4. Configure the API URL, API key and header name in **Settings > ChatBotWindow**.
+5. Add the `[chatbot_window]` shortcode to a page where you want the chat interface.
 
 ## Repository Structure
 


### PR DESCRIPTION
## Summary
- support configurable API key header field
- remove unused HTML generator for tasks
- add `[chatbot_window]` shortcode for embedding the chat window
- document new header option and shortcode usage

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68424fda19ac8323b07229b0d9307505